### PR TITLE
Hooks for CRB load time benchmarks

### DIFF
--- a/talperformancemonitor.js
+++ b/talperformancemonitor.js
@@ -147,6 +147,14 @@
                 // Do our report after the attach has completed, so CRB gets the best data around this call.
                 utils.sendStatistic('keyHandler_attach', utils.timeFromStart());
             }
+        },
+        'redbuttonhtml/appui/widgets/rbhorizontalcarousel': function(object) {
+            var original = object.prototype.fadeInCollectionItemButtons;
+            object.prototype.fadeInCollectionItemButtons = function () {
+                original.call(this);
+                // Do report after the fade in animation has been kicked off, so CRB gets the best data around this call.
+                utils.sendStatistic('rbhorizontalcarousel_fadeInCollectionItemButtons', utils.timeFromStart());
+            }
         }
 	};
 

--- a/talperformancemonitor.js
+++ b/talperformancemonitor.js
@@ -2,7 +2,7 @@
 	var startTime = new Date();
 
 	var config = {
-		server : '10.10.14.27:3000'
+		server : '10.94.12.85:3000'
 	}; 
 
 	var utils = {
@@ -127,7 +127,27 @@
 				}
 				originalDeviceTween.call(this, options)
 			}
-		}
+		},
+        'antie/widgets/widget': function (object) {
+            var original = object.prototype.bubbleEvent;
+            object.prototype.bubbleEvent = function (ev) {
+                var timeElapsed = utils.timeFromStart();
+                var id = this.id;
+                if (id.substr(0,1) == '#') {
+                    id = 'ROOT';
+                }
+                utils.sendStatistic('bubbleEvent_' + ev.type + '_' + id, timeElapsed);
+                original.call(this,ev);
+            };
+        },
+        'antie/widgets/carousel/keyhandlers/keyhandler' : function(object) {
+            var original = object.prototype.attach;
+            object.prototype.attach = function (carousel) {
+                original.call(this, carousel);
+                // Do our report after the attach has completed, so CRB gets the best data around this call.
+                utils.sendStatistic('keyHandler_attach', utils.timeFromStart());
+            }
+        }
 	};
 
 	var statEvents = {

--- a/talperformancemonitor.js
+++ b/talperformancemonitor.js
@@ -63,7 +63,9 @@
 					var start = new Date();
 					originalOnSuccess(data);
 
-					var forceUpdate = window.getComputedStyle(widget.outputElement, null).width;
+					if (widget.outputElement) {
+						var forceUpdate = window.getComputedStyle(widget.outputElement, null).width;
+					}
 					var end = new Date();
 					utils.sendStatistic('bind_success_time_for_' + utils.formatId(widget.id), end - start);
 				};


### PR DESCRIPTION
See CRB wiki page for details of individual journeys. Exposes event bubbling, carousel key handler attaching and CRB-specific collection item fade in.
